### PR TITLE
Use exit code to signal if there are unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-machete"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",


### PR DESCRIPTION
Addresses part of https://github.com/bnjbvr/cargo-machete/issues/13.

The application now returns 0 if no unused dependencies are found, 1 if unused dependencies are found, and 2 for any other errors (propagated via `Result`).

What could still be improved in a separate PR:
* Error handling (it looks like syntax errors in some `Cargo.toml` files are skipped instead of causing an error; not sure if intended)
* Machine-readable, stable output