### PR TITLE
Render contributing badge as an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ names, more accurate dependencies per build type, etc. ⚠ This may modify the
 
 ## Contributing
 
-![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)
+[![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)](https://www.contributor-covenant.org/version/1/4/code-of-conduct/)
 
 We welcome community contributions to this project.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ names, more accurate dependencies per build type, etc. ⚠ This may modify the
 
 ## Contributing
 
-[Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)
+![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)
 
 We welcome community contributions to this project.
 


### PR DESCRIPTION
I noticed that "Contributing" was linking to an SVG. Assuming this wasn't intentional, I changed it to render as an image instead.

In a second commit (in case it's an unwanted change) I made the `contributor covenant 1.4` badge link to the relevant webpage. Although I haven't used it before, it states that [you must have a some sort of visible code of conduct documentation (e.g. `CODE_OF_CONDUCT.md`)](https://www.contributor-covenant.org/#how-to-adopt-contributor-covenant). It also states that the placeholder (`[INSERT EMAIL ADDRESS]`) in the contributor covenant must be replaced with contact info to report code of conduct violations. Based on that, you might want a `CODE_OF_CONDUCT.md` added.