### PR TITLE
Replace walkdir with ignore for better path walking defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,12 +80,12 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "grep",
+ "ignore",
  "log",
  "pretty_env_logger",
  "rayon",
  "serde",
  "toml_edit",
- "walkdir",
 ]
 
 [[package]]
@@ -343,6 +343,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
+anyhow = "1.0.57"
+cargo_metadata = "0.14.2"
 cargo_toml = "0.13.0"
 grep = "0.2.8"
+ignore = "0.4.18"
 log = "0.4.16"
 pretty_env_logger = "0.4.0"
-walkdir = "2.3.2"
-anyhow = "1.0.57"
 rayon = "1.5.2"
-cargo_metadata = "0.14.2"
 serde = "1.0.136"
 toml_edit = { version = "0.14.3", features = ["easy", "serde"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,9 @@ fn build_toml_file_iterator(path: &Path, args: &MacheteArgs) -> impl Iterator<It
     let mut walk_builder = ignore::WalkBuilder::new(path);
     walk_builder.filter_entry(|entry| entry.file_name() == "Cargo.toml");
     if args.skip_target_dir {
-        walk_builder.add_ignore("target/");
+        if let Some(error) = walk_builder.add_ignore("target/") {
+            return Err(error);
+        }
     }
     walk_builder.build()
 }

--- a/src/search_unused.rs
+++ b/src/search_unused.rs
@@ -10,7 +10,6 @@ use std::{
     error,
     path::{Path, PathBuf},
 };
-use walkdir::WalkDir;
 
 #[cfg(test)]
 use crate::TOP_LEVEL;
@@ -138,7 +137,7 @@ fn collect_paths(dir_path: &Path, analysis: &PackageAnalysis) -> Vec<PathBuf> {
     // Collect all final paths for the crate first.
     let paths: Vec<PathBuf> = root_paths
         .iter()
-        .flat_map(|root| WalkDir::new(dir_path.join(root)).into_iter())
+        .flat_map(|root| ignore::Walk::new(dir_path.join(root)).into_iter())
         .filter_map(|result| {
             let dir_entry = match result {
                 Ok(dir_entry) => dir_entry,
@@ -147,7 +146,11 @@ fn collect_paths(dir_path: &Path, analysis: &PackageAnalysis) -> Vec<PathBuf> {
                     return None;
                 }
             };
-            if !dir_entry.file_type().is_file() {
+            if !dir_entry
+                .file_type()
+                .map(|t| t.is_file())
+                .unwrap_or_default()
+            {
                 return None;
             }
             if dir_entry

--- a/src/search_unused.rs
+++ b/src/search_unused.rs
@@ -137,7 +137,7 @@ fn collect_paths(dir_path: &Path, analysis: &PackageAnalysis) -> Vec<PathBuf> {
     // Collect all final paths for the crate first.
     let paths: Vec<PathBuf> = root_paths
         .iter()
-        .flat_map(|root| ignore::Walk::new(dir_path.join(root)).into_iter())
+        .flat_map(|root| ignore::Walk::new(dir_path.join(root)))
         .filter_map(|result| {
             let dir_entry = match result {
                 Ok(dir_entry) => dir_entry,


### PR DESCRIPTION
The `ignore` crate (also by Burntsushi) has good defaults for walking the file system, like for example not recursing into ignored directories.

On the implementation side, instead of building a parallel iterator through rayon, we could also use the parallel walker exposed by ignore. We will have to implement a visitor type to collect the analysis results though. I opted not to do this in the initial PR to limit the amount of changes.
