### PR TITLE
Use argh for argument parsing (fixes #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- *Breaking*: Use `argh` for parsing. Now, paths of directories to scan must be passed in the last
+  position, when running from the command line (#51).
 - Fix rare false positive and speed up most common case (#53).
 
 # 0.4.0 (released on 2022-10-16)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "argh"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c375edecfd2074d5edcc31396860b6e54b6f928714d0e097b983053fac0cabe3"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa013479b80109a1bf01a039412b0f0013d716f36921226d86c6709032fb7a03"
+dependencies = [
+ "argh_shared",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149f75bbec1827618262e0855a68f0f9a7f2edc13faebf33c4f16d6725edb6a9"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +106,7 @@ name = "cargo-machete"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "argh",
  "cargo_metadata",
  "cargo_toml",
  "grep",
@@ -326,6 +356,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,17 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
+anyhow = "1.0.57"
+argh = "0.1.9"
+cargo_metadata = "0.14.2"
 cargo_toml = "0.13.0"
 grep = "0.2.8"
 log = "0.4.16"
 pretty_env_logger = "0.4.0"
-walkdir = "2.3.2"
-anyhow = "1.0.57"
 rayon = "1.5.2"
-cargo_metadata = "0.14.2"
 serde = "1.0.136"
 toml_edit = { version = "0.14.3", features = ["easy", "serde"] }
+walkdir = "2.3.2"
 
 # Uncomment this for profiling.
 #[profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,12 @@ fn collect_paths(path: &Path, skip_target_dir: bool) -> Vec<PathBuf> {
 fn run_machete() -> anyhow::Result<bool> {
     pretty_env_logger::init();
 
-    let mut has_unused_dependencies = false;
-    let mut args: MacheteArgs = argh::from_env();
+    let mut args: MacheteArgs = if std::env::var("CARGO").is_ok() {
+        // Running as "cargo machete": remove the first argument.
+        argh::cargo_from_env()
+    } else {
+        argh::from_env()
+    };
 
     if args.paths.is_empty() {
         eprintln!("Analyzing dependencies of crates in this directory...");
@@ -114,6 +118,8 @@ fn run_machete() -> anyhow::Result<bool> {
                 .join(",")
         );
     }
+
+    let mut has_unused_dependencies = false;
 
     for path in args.paths {
         let manifest_path_entries = collect_paths(&path, args.skip_target_dir);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod search_unused;
 
-use crate::search_unused::{find_unused, UseCargoMetadata};
+use crate::search_unused::find_unused;
 use anyhow::Context;
 use rayon::prelude::*;
 use std::path::Path;
@@ -8,91 +8,63 @@ use std::str::FromStr;
 use std::{fs, path::PathBuf};
 use walkdir::WalkDir;
 
-struct MacheteArgs {
-    fix: bool,
-    use_cargo_metadata: UseCargoMetadata,
-    paths: Vec<PathBuf>,
-    skip_target_dir: bool,
+#[derive(Clone, Copy)]
+pub(crate) enum UseCargoMetadata {
+    Yes,
+    No,
 }
 
-const HELP: &str = r#"cargo-machete: Helps find unused dependencies in a fast yet imprecise way.
+#[cfg(test)]
+impl UseCargoMetadata {
+    fn all() -> &'static [UseCargoMetadata] {
+        &[UseCargoMetadata::Yes, UseCargoMetadata::No]
+    }
+}
 
-Example usage: cargo-machete [PATH1] [PATH2] [--flags]?
+impl From<UseCargoMetadata> for bool {
+    fn from(v: UseCargoMetadata) -> bool {
+        matches!(v, UseCargoMetadata::Yes)
+    }
+}
 
-Flags:
+impl From<bool> for UseCargoMetadata {
+    fn from(b: bool) -> Self {
+        if b {
+            Self::Yes
+        } else {
+            Self::No
+        }
+    }
+}
 
-    --help / -h: displays this help message.
-
-    --with-metadata: uses cargo-metadata to figure out the dependencies' names. May be useful if
-                     some dependencies are renamed from their own Cargo.toml file (e.g. xml-rs
-                     which gets renamed xml). Try it if you get false positives!
-
-    --skip-target-dir: don't analyze anything contained in any target/ directories encountered.
-
-    --fix: rewrite the Cargo.toml files to automatically remove unused dependencies.
-           Note: all dependencies flagged by cargo-machete will be removed, including false
-           positives.
+#[derive(argh::FromArgs)]
+#[argh(description = r#"
+cargo-machete: Helps find unused dependencies in a fast yet imprecise way.
 
 Exit code:
-
     0:  when no unused dependencies are found
     1:  when at least one unused (non-ignored) dependency is found
     2:  on error
-"#;
+"#)]
+struct MacheteArgs {
+    /// uses cargo-metadata to figure out the dependencies' names. May be useful if some
+    /// dependencies are renamed from their own Cargo.toml file (e.g. xml-rs which gets renamed
+    /// xml). Try it if you get false positives!
+    #[argh(switch)]
+    with_metadata: bool,
 
-fn parse_args() -> anyhow::Result<MacheteArgs> {
-    let mut fix = false;
-    let mut use_cargo_metadata = UseCargoMetadata::No;
-    let mut skip_target_dir = false;
+    /// don't analyze anything contained in any target/ directories encountered.
+    #[argh(switch)]
+    skip_target_dir: bool,
 
-    let mut path_str = Vec::new();
-    let args = std::env::args();
+    /// rewrite the Cargo.toml files to automatically remove unused dependencies.
+    /// Note: all dependencies flagged by cargo-machete will be removed, including false positives.
+    #[argh(switch)]
+    fix: bool,
 
-    for (i, arg) in args.into_iter().enumerate() {
-        // Ignore the binary name...
-        if i == 0 {
-            continue;
-        }
-        // ...and the "machete" command if ran as cargo subcommand.
-        if i == 1 && arg == "machete" {
-            continue;
-        }
-
-        if arg == "help" || arg == "-h" || arg == "--help" {
-            eprintln!("{}", HELP);
-            std::process::exit(0);
-        }
-
-        if arg == "--fix" {
-            fix = true;
-        } else if arg == "--with-metadata" {
-            use_cargo_metadata = UseCargoMetadata::Yes;
-        } else if arg == "--skip-target-dir" {
-            skip_target_dir = true;
-        } else if arg.starts_with('-') {
-            anyhow::bail!("invalid parameter {arg}. Usage:\n{HELP}");
-        } else {
-            path_str.push(arg);
-        }
-    }
-
-    let paths = if path_str.is_empty() {
-        eprintln!("Analyzing dependencies of crates in this directory...");
-        vec![std::env::current_dir()?]
-    } else {
-        eprintln!(
-            "Analyzing dependencies of crates in {}...",
-            path_str.join(",")
-        );
-        path_str.into_iter().map(PathBuf::from).collect()
-    };
-
-    Ok(MacheteArgs {
-        fix,
-        use_cargo_metadata,
-        paths,
-        skip_target_dir,
-    })
+    /// paths to directories that must be scanned.
+    #[argh(positional, greedy)]
+    paths: Vec<PathBuf>,
 }
 
 fn collect_paths(path: &Path, skip_target_dir: bool) -> Vec<PathBuf> {
@@ -126,7 +98,22 @@ fn run_machete() -> anyhow::Result<bool> {
     pretty_env_logger::init();
 
     let mut has_unused_dependencies = false;
-    let args = parse_args()?;
+    let mut args: MacheteArgs = argh::from_env();
+
+    if args.paths.is_empty() {
+        eprintln!("Analyzing dependencies of crates in this directory...");
+        args.paths.push(std::env::current_dir()?);
+    } else {
+        eprintln!(
+            "Analyzing dependencies of crates in {}...",
+            args.paths
+                .iter()
+                .cloned()
+                .map(|path| path.as_os_str().to_string_lossy().to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+    }
 
     for path in args.paths {
         let manifest_path_entries = collect_paths(&path, args.skip_target_dir);
@@ -135,8 +122,8 @@ fn run_machete() -> anyhow::Result<bool> {
         // used by any Rust crate.
         let results = manifest_path_entries
             .par_iter()
-            .filter_map(
-                |manifest_path| match find_unused(manifest_path, args.use_cargo_metadata) {
+            .filter_map(|manifest_path| {
+                match find_unused(manifest_path, args.with_metadata.into()) {
                     Ok(Some(analysis)) => {
                         if analysis.unused.is_empty() {
                             None
@@ -157,8 +144,8 @@ fn run_machete() -> anyhow::Result<bool> {
                         eprintln!("error when handling {}: {}", manifest_path.display(), err);
                         None
                     }
-                },
-            )
+                }
+            })
             .collect::<Vec<_>>();
 
         // Display all the results.

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,9 +222,6 @@ fn remove_dependencies(manifest: &str, dependencies_list: &[String]) -> anyhow::
 }
 
 fn main() {
-    for (k, v) in std::env::vars_os() {
-        println!("ENV: {} = {}", k.to_string_lossy(), v.to_string_lossy());
-    }
     let exit_code = match run_machete() {
         Ok(false) => 0,
         Ok(true) => 1,

--- a/src/search_unused.rs
+++ b/src/search_unused.rs
@@ -13,6 +13,7 @@ use std::{
 };
 use walkdir::WalkDir;
 
+use crate::UseCargoMetadata;
 #[cfg(test)]
 use crate::TOP_LEVEL;
 
@@ -255,25 +256,6 @@ impl Search {
         self.try_singleline_then_multiline(|searcher, matcher, sink| {
             searcher.search_reader(matcher, s.as_bytes(), sink)
         })
-    }
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum UseCargoMetadata {
-    Yes,
-    No,
-}
-
-#[cfg(test)]
-impl UseCargoMetadata {
-    fn all() -> &'static [UseCargoMetadata] {
-        &[UseCargoMetadata::Yes, UseCargoMetadata::No]
-    }
-}
-
-impl From<UseCargoMetadata> for bool {
-    fn from(v: UseCargoMetadata) -> bool {
-        matches!(v, UseCargoMetadata::Yes)
     }
 }
 


### PR DESCRIPTION
Fixes #12.
Fixes #22. Turns out there's a `CARGO` env variable that's set whenever a program is running as a cargo subcommand.