### PR TITLE
Split single-line and multi-line matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix rare false positive and speed up most common case (#53).
+
 # 0.4.0 (released on 2022-10-16)
 
 - Added `--skip-target-dir` to not analyze `target/` directories.


### PR DESCRIPTION
This adds two test cases that were failing before the accompanying change.

Basically: regular expressions are hard.

A single multi-line regular expression was used, but some of its subsets would have weird behaviors, especially if the preceding line was a comment. The sink would receive a multi-line match that started with a comment, and thus incorrectly classified the whole match as a comment, while the second line was, in fact, _not_ a comment, so that would result in a false positive.

Splitting the regular expression in one that operates on single-line and another one that operates on multiple-lines has a few benefits:

- the `grep` crates have a few optimizations when the searcher and matcher are line-based
- it's likely that we rarely have to use the multiline matcher, so most of the time the line-based search should suffice
- code maintenance is easier, as I find it easier to reason about the line matchers separately from the multi-line monstrosity