### PR TITLE
Fix ci warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -71,7 +71,7 @@ jobs:
         run: |
           sudo apt-get install -y musl-tools
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cargo fetch
         run: cargo fetch --target ${{ matrix.target }}
       - name: Release build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - run: cargo fmt --all --check
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v1
@@ -75,10 +74,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           target: ${{ matrix.target }}
       - name: Install musl tools
         if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,23 +30,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all --check
 
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --all-features -- -D warnings
+      - run: cargo clippy --all --all-features -- -D warnings
 
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --verbose
+      - run: cargo test --workspace --verbose
 
   # Code mutably borrowed from https://github.com/EmbarkStudios/cargo-deny/, thanks Embark!
   release:


### PR DESCRIPTION
Fixes deprecation warnings due to unmaintained actions or old version actions.

- Replaces `actions-rs/toolchain` with `dtolnay/rust-toolchain` as the former is unmaintained.
    - https://github.com/actions-rs/toolchain/issues/216
    - `dtolnay/rust-toolchain` is now a famous action to setup rust toolchain, for example which is used in tokio and the other a lot of projects.
    - As GitHub Actions' default environment contains `rustup`, we can also use the `rustup`. So if it is more appropriate in this project, I will fix to use it instead of the GitHub Action (for example: [`cargo` project](https://github.com/rust-lang/cargo/blob/0.70.1/.github/workflows/main.yml#L21-L22), [`rust-analyzer` project](https://github.com/rust-lang/rust-analyzer/blob/2023-05-29/.github/workflows/ci.yaml#L62-L65)) .
- Replaces `actions-rs/cargo` with `run:` as the former is unmaintained.
    - Same as `actions-rs/toolchain`, `actions-rs` has not been updated for a long time.
- Updates to `actions/checkout@v3` from version 2.
- Updates to `Swatinem/rust-cache@v2` from version 1.