### PR TITLE
Print message to help user manage false positives

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -212,30 +212,26 @@ fn run_machete() -> anyhow::Result<bool> {
     }
 
     if has_unused_dependencies {
+        println!(
+            "\n\
+            If you believe cargo-machete has detected an unused dependency incorrectly,\n\
+            you can add the dependency to the list of dependencies to ignore in the\n\
+            `[package.metadata.cargo-machete]` section of the appropriate Cargo.toml.\n\
+            For example:\n\
+            \n\
+            [package.metadata.cargo-machete]\n\
+            ignored = [\"prost\"]"
+        );
+
         if !args.with_metadata {
-            println!("\n\
-                If you believe cargo-machete has detected an unused dependency incorrectly,\n\
-                you can try running it with the `--with-metadata` flag for better accuracy,\n\
-                though this may modify your Cargo.lock files.\n\
-                \n\
-                You can also add the dependency to the list of dependencies to ignore in the\n\
-                `[package.metadata.cargo-machete]` section of the appropriate Cargo.toml file.\n\
-                For example:\n\
-                \n\
-                [package.metadata.cargo-machete]\n\
-                ignored = [\"prost\"]\n"
-            );
-        } else {
-            println!("\n\
-                If you believe cargo-machete has detected an unused dependency incorrectly,\n\
-                you can add the dependency to the list of dependencies to ignore in the\n\
-                `[package.metadata.cargo-machete]` section of the appropriate Cargo.toml file.\n\
-                For example:\n\
-                \n\
-                [package.metadata.cargo-machete]\n\
-                ignored = [\"prost\"]\n"
+            println!(
+                "\n\
+                You can also try running it with the `--with-metadata` flag for better accuracy,\n\
+                though this may modify your Cargo.lock files."
             );
         }
+
+        println!()
     }
 
     eprintln!("Done!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,17 @@ fn run_machete() -> anyhow::Result<bool> {
         }
     }
 
+    if has_unused_dependencies {
+        println!("\n\
+            If you believe cargo-machete has detected an unused dependency incorrectly, you may add it\n\
+            to the list of dependencies to ignore in the `[package.metadata.cargo-machete]` section of\n\
+            the appropriate Cargo.toml file. For example:\n\
+            \n\
+            [package.metadata.cargo-machete]\n\
+            ignored = [\"prost\"]\n"
+        );
+    }
+
     eprintln!("Done!");
 
     if !walkdir_errors.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,14 +212,30 @@ fn run_machete() -> anyhow::Result<bool> {
     }
 
     if has_unused_dependencies {
-        println!("\n\
-            If you believe cargo-machete has detected an unused dependency incorrectly, you may add it\n\
-            to the list of dependencies to ignore in the `[package.metadata.cargo-machete]` section of\n\
-            the appropriate Cargo.toml file. For example:\n\
-            \n\
-            [package.metadata.cargo-machete]\n\
-            ignored = [\"prost\"]\n"
-        );
+        if !args.with_metadata {
+            println!("\n\
+                If you believe cargo-machete has detected an unused dependency incorrectly,\n\
+                you can try running it with the `--with-metadata` flag for better accuracy,\n\
+                though this may modify your Cargo.lock files.\n\
+                \n\
+                You can also add the dependency to the list of dependencies to ignore in the\n\
+                `[package.metadata.cargo-machete]` section of the appropriate Cargo.toml file.\n\
+                For example:\n\
+                \n\
+                [package.metadata.cargo-machete]\n\
+                ignored = [\"prost\"]\n"
+            );
+        } else {
+            println!("\n\
+                If you believe cargo-machete has detected an unused dependency incorrectly,\n\
+                you can add the dependency to the list of dependencies to ignore in the\n\
+                `[package.metadata.cargo-machete]` section of the appropriate Cargo.toml file.\n\
+                For example:\n\
+                \n\
+                [package.metadata.cargo-machete]\n\
+                ignored = [\"prost\"]\n"
+            );
+        }
     }
 
     eprintln!("Done!");


### PR DESCRIPTION
When unused dependencies are found, print a message that tells the user how to manage false positives.

Example output:

```
Analyzing dependencies of crates in this directory...
cargo-machete found the following unused dependencies in /home/tgnottingham/example:
example -- /home/tgnottingham/example/Cargo.toml:
        fxhash

If you believe cargo-machete has detected an unused dependency incorrectly, you may add it
to the list of dependencies to ignore in the `[package.metadata.cargo-machete]` section of
the appropriate Cargo.toml file. For example:

[package.metadata.cargo-machete]
ignored = ["prost"]

Done!
```