### PR TITLE
Prevent Cargo.toml search from going on longer than it should

### DIFF
--- a/src/search_unused.rs
+++ b/src/search_unused.rs
@@ -283,8 +283,8 @@ fn get_full_manifest(
     let mut ws_manifest_and_path = None;
     let mut workspace_ignored = vec![];
 
-    let mut dir_path = dir_path.join("../");
-    while dir_path.exists() {
+    let mut dir_path = dir_path.to_path_buf();
+    while dir_path.pop() {
         let workspace_cargo_path = dir_path.join("Cargo.toml");
         if let Ok(workspace_manifest) =
             cargo_toml::Manifest::<PackageMetadata>::from_path_with_metadata(&workspace_cargo_path)
@@ -304,7 +304,6 @@ fn get_full_manifest(
                 break;
             }
         }
-        dir_path = dir_path.join("../");
     }
 
     manifest.complete_from_path_and_workspace(


### PR DESCRIPTION
The Cargo.toml search approach that looks at all ancestor directories goes on longer than it should. The problem is that it constructs paths like "/example/../../../../..", but that path is considered to exist, so the loop would continue on until the path was too long to be valid.

Noticed this while running machete under strace to see what paths it was looking at, in order to diagnose a false positive.