### PR TITLE
Fixes #104: correctly parse id repr for Rust 1.78+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         rust:
           - stable
-          #- nightly # re-enable once #104 has been fixed
+          - nightly
 
     steps:
       - uses: actions/checkout@v3

--- a/src/search_unused.rs
+++ b/src/search_unused.rs
@@ -297,7 +297,7 @@ fn get_full_manifest(
                     .and_then(|metadata| metadata.cargo_machete.as_ref())
                     .map(|machete| &machete.ignored)
                 {
-                    workspace_ignored = ignored.clone();
+                    workspace_ignored.clone_from(ignored);
                 }
 
                 ws_manifest_and_path = Some((workspace_manifest, workspace_cargo_path));

--- a/src/search_unused.rs
+++ b/src/search_unused.rs
@@ -360,6 +360,10 @@ pub(crate) fn find_unused(
                 // - on rust 1.78+, something like:
                 //  - "path+file:///home/ben/cargo-machete/integration-tests/aa#0.1.0"
                 //  - "path+file:///home/ben/cargo-machete/integration-tests/directory#aa@0.1.0"
+                //
+                //  See https://doc.rust-lang.org/cargo/reference/pkgid-spec.html for the full
+                //  spec. If this breaks in the future (>= March 2024), consider using
+                //  `cargo-util-schemas`.
                 let repr = &node.id.repr;
 
                 let package_found = if repr.contains(' ') {


### PR DESCRIPTION
This updates to the new pkgid spec used after Rust 1.77.

Fixes #104.
Fixes #114.