### PR TITLE
feat: when using the current working directory, use `.` as the base and not the absolute path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn run_machete() -> anyhow::Result<bool> {
 
     if args.paths.is_empty() {
         eprintln!("Analyzing dependencies of crates in this directory...");
-        args.paths.push(std::env::current_dir()?);
+        args.paths.push(PathBuf::from("."));
     } else {
         eprintln!(
             "Analyzing dependencies of crates in {}...",


### PR DESCRIPTION
This makes output much shorter and has not possiblity of failure too.

Example:

```
python-bindings -- ./python-bindings/Cargo.toml:
	pyo3_build_config

python-bindings -- /Users/poliorcetics/repos/work/int/main-project/rust-code/python-bindings/Cargo.toml:
	pyo3_build_config
```