### PR TITLE
Use custom envvar `CARGO_MACHETE_LOG` as log filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added: `--ignore` flag which make cargo-machete respect .ignore and .gitignore files when searching for files (#95).
 
+- Change log filter environment variable from `RUST_LOG` to `CARGO_MACHETE_LOG`.
+
 # 0.6.2 (released on 2024-03-24)
 
 - Added: shorter display when scanning the current directory (#109).

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn running_as_cargo_cmd() -> bool {
 /// Runs `cargo-machete`.
 /// Returns Ok with a bool whether any unused dependencies were found, or Err on errors.
 fn run_machete() -> anyhow::Result<bool> {
-    pretty_env_logger::init();
+    pretty_env_logger::init_custom_env("CARGO_MACHETE_LOG");
 
     let mut args: MacheteArgs = if running_as_cargo_cmd() {
         argh::cargo_from_env()


### PR DESCRIPTION
This makes it more project-specific and avoid spamming unintended logs for users having `RUST_LOG=debug` in their development environment.