### PR TITLE
fix: canonicalize relative paths when looking for the workspace manifest

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ fn run_machete() -> anyhow::Result<bool> {
                     }
 
                     Err(err) => {
-                        eprintln!("error when handling {}: {}", manifest_path.display(), err);
+                        eprintln!("error when handling {}: {:#}", manifest_path.display(), err);
                         None
                     }
                 },


### PR DESCRIPTION
Fixes #135.