### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: cargo-machete
+  name: cargo-machete
+  description: Run cargo machete to find unused Rust dependencies
+  language: rust
+  entry: cargo machete
+  types_or:
+    - cargo
+    - cargo-lock
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ jobs:
         uses: bnjbvr/cargo-machete@main
 ```
 
+## `pre-commit` Hooks
+
+`cargo machete` can be used as a [`pre-commit`](https://pre-commit.com/) hook to check for unused dependencies before committing changes.
+
+Add the following to your `.pre-commit-config.yaml`:
+
+```yaml
+- repo: https://github.com/bnjbvr/cargo-machete
+  rev: main  # or a specific tag/commit
+  hooks:
+    - id: cargo-machete
+```
+
 ## Contributing
 
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)](https://www.contributor-covenant.org/version/1/4/code-of-conduct/)


### PR DESCRIPTION
This will allow people to run `cargo machete` as part of their pre-commit workflow like this:

```yaml
  - repo: https://github.com/bnjbvr/cargo-machete
    rev: v0.8.0  # <-- replace with first release containing the hook
    hooks:
      - id: cargo-machete
```