### PR TITLE
doc: rename job name in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ on:
   pull_request: { branches: "*" }
 
 jobs:
-  build:
+  detect-unused-dependencies:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Thank you for maintaining such a useful tool!

It's a minor point, but I felt that the job name `build` was slightly inappropriate.

Therefore, I renamed it to `detect-unused-dependencies`.