### PR TITLE
refactor(action): try to install a precompiled cargo-machete from the release page

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,54 +17,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Determine platform triple
-      shell: bash
-      id: platform
-      run: |
-        TRIPLE=$(rustc -vV | grep host | awk '{print $2}')
-        if [[ "$TRIPLE" == *"unknown-linux"* && "$TRIPLE" == *"x86_64"* ]]; then
-          # Replace 'gnu' with 'musl' only for linux x86_64.
-          TRIPLE="${TRIPLE/gnu/musl}"
-        fi
-        echo "TRIPLE=${TRIPLE}" >> $GITHUB_ENV
-
-
-    - name: Get latest release version
-      id: get_version
-      shell: bash
-      run: |
-        VERSION=$(curl -s https://api.github.com/repos/bnjbvr/cargo-machete/releases/latest | jq -r .tag_name)
-        echo "VERSION=${VERSION}" >> $GITHUB_ENV
-
-    - name: Install a precompiled or compile `cargo-machete``cargo-machete`
+    - name: Install precompiled or compile `cargo-machete`
       id: download
       shell: bash
-      run: |
-        TRIPLE=${{ env.TRIPLE }}
-        VERSION=${{ env.VERSION }}
-        ARCHIVE_URL="https://github.com/bnjbvr/cargo-machete/releases/download/${VERSION}/cargo-machete-${VERSION}-${TRIPLE}.tar.gz"
-
-        if curl --output /dev/null --silent --head --fail "$ARCHIVE_URL"; then
-          echo "Downloading precompiled binary from $ARCHIVE_URL"
-          curl -L -o cargo-machete.tar.gz "$ARCHIVE_URL"
-          tar -xzf cargo-machete.tar.gz
-          mv cargo*/cargo-machete /usr/local/bin/cargo-machete
-          chmod +x /usr/local/bin/cargo-machete
-          echo "cargo-machete downloaded and extracted successfully."
-        else
-          echo "Precompiled binary not found for $TRIPLE. Falling back to cargo install."
-          cargo install cargo-machete
-        fi
-
-    - name: Verify installation
-      shell: bash
-      run: |
-        if command -v cargo-machete; then
-          echo "cargo-machete installed successfully."
-        else
-          echo "cargo-machete installation failed."
-          exit 1
-        fi
+      run: $GITHUB_ACTION_PATH/action/entrypoint.sh
 
     - name: Run `cargo-machete`
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,19 +1,72 @@
 name: 'cargo-machete'
+
 description: 'A github action for cargo machete'
+
 author: 'Cargo machete community'
+
 branding:
   color: "black"
   icon: "code"
+
+inputs:
+  args:
+    description: 'Extra arguments to pass to the `cargo-machete` invoke'
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
-    - name: Install cargo-machete
-      uses: clechasseur/rs-cargo@v4
-      with:
-        command: install
-        args: cargo-machete@0.9.1
-        toolchain: stable
-    - name: Machete
-      uses: clechasseur/rs-cargo@v4
-      with:
-        command: machete
+    - name: Determine platform triple
+      shell: bash
+      id: platform
+      run: |
+        TRIPLE=$(rustc -vV | grep host | awk '{print $2}')
+        if [[ "$TRIPLE" == *"unknown-linux"* && "$TRIPLE" == *"x86_64"* ]]; then
+          # Replace 'gnu' with 'musl' only for linux x86_64.
+          TRIPLE="${TRIPLE/gnu/musl}"
+        fi
+        echo "TRIPLE=${TRIPLE}" >> $GITHUB_ENV
+
+
+    - name: Get latest release version
+      id: get_version
+      shell: bash
+      run: |
+        VERSION=$(curl -s https://api.github.com/repos/bnjbvr/cargo-machete/releases/latest | jq -r .tag_name)
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+    - name: Install a precompiled or compile `cargo-machete``cargo-machete`
+      id: download
+      shell: bash
+      run: |
+        TRIPLE=${{ env.TRIPLE }}
+        VERSION=${{ env.VERSION }}
+        ARCHIVE_URL="https://github.com/bnjbvr/cargo-machete/releases/download/${VERSION}/cargo-machete-${VERSION}-${TRIPLE}.tar.gz"
+
+        if curl --output /dev/null --silent --head --fail "$ARCHIVE_URL"; then
+          echo "Downloading precompiled binary from $ARCHIVE_URL"
+          curl -L -o cargo-machete.tar.gz "$ARCHIVE_URL"
+          tar -xzf cargo-machete.tar.gz
+          mv cargo*/cargo-machete /usr/local/bin/cargo-machete
+          chmod +x /usr/local/bin/cargo-machete
+          echo "cargo-machete downloaded and extracted successfully."
+        else
+          echo "Precompiled binary not found for $TRIPLE. Falling back to cargo install."
+          cargo install cargo-machete
+        fi
+
+    - name: Verify installation
+      shell: bash
+      run: |
+        if command -v cargo-machete; then
+          echo "cargo-machete installed successfully."
+        else
+          echo "cargo-machete installation failed."
+          exit 1
+        fi
+
+    - name: Run `cargo-machete`
+      shell: bash
+      run: |
+        cargo-machete ${{ inputs.args }}

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -eu
+
+# Determine the Rust target triple using rustc.
+echo "Determining Rust target triple..."
+TRIPLE=$(rustc -vV | grep host | awk '{print $2}')
+if [[ "$TRIPLE" == *"unknown-linux"* && "$TRIPLE" == *"x86_64"* ]]; then
+  # Replace 'gnu' with 'musl' only for linux x86_64.
+  TRIPLE="${TRIPLE/gnu/musl}"
+fi
+echo "Found TRIPLE=${TRIPLE}."
+
+# Fetch the latest version of cargo-machete from GitHub releases.
+VERSION=$(curl -s https://api.github.com/repos/bnjbvr/cargo-machete/releases/latest | jq -r .tag_name)
+echo "Found VERSION=${VERSION}."
+
+# Download the precompiled binary if available, otherwise fall back to cargo install.
+ARCHIVE_URL="https://github.com/bnjbvr/cargo-machete/releases/download/${VERSION}/cargo-machete-${VERSION}-${TRIPLE}.tar.gz"
+
+if curl --output /dev/null --silent --head --fail "$ARCHIVE_URL"; then
+  echo "Downloading precompiled binary from $ARCHIVE_URL…"
+  curl -L -o cargo-machete.tar.gz "$ARCHIVE_URL"
+  tar -xzf cargo-machete.tar.gz
+  mv cargo*/cargo-machete /usr/local/bin/cargo-machete
+  chmod +x /usr/local/bin/cargo-machete
+  echo "cargo-machete downloaded and extracted successfully."
+else
+  echo "Precompiled binary not found for $TRIPLE. Falling back to cargo install."
+  cargo install cargo-machete
+fi
+
+# Finally, test the installation.
+if command -v cargo-machete; then
+  echo "cargo-machete installed successfully."
+else
+  echo "cargo-machete installation failed."
+  exit 1
+fi


### PR DESCRIPTION
This introduces a few changes:

- stop using the [rs-cargo](https://github.com/clechasseur/rs-cargo) action. I'm not sure what benefits it did provide over using a plain `cargo` invoke.
- try to download a precompiled binary artifact, so there's no compilation involved in the installation at all, and the action can run blazingly fast. Revert to a `cargo install`, if there's no precompiled binary for the current platform.