### PR TITLE
Fix base image to Debian 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src
 RUN cargo install --path /src --locked
 RUN apt update && apt -y install tini
 
-FROM gcr.io/distroless/cc-debian12
+FROM gcr.io/distroless/cc-debian13
 COPY --from=build /usr/local/cargo/bin/cargo-machete /usr/local/bin/
 COPY --from=build /usr/bin/tini-static /tini
 


### PR DESCRIPTION
This should solve this error:

```
/usr/local/bin/cargo-machete: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /usr/local/bin/cargo-machete)
```

This is a result of `rust:slim` now based on `trixie`.