### PR TITLE
Separate the ARCHIVE_URL symbol for proper parsing in bash

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -19,7 +19,7 @@ echo "Found VERSION=${VERSION}."
 ARCHIVE_URL="https://github.com/bnjbvr/cargo-machete/releases/download/${VERSION}/cargo-machete-${VERSION}-${TRIPLE}.tar.gz"
 
 if curl --output /dev/null --silent --head --fail "$ARCHIVE_URL"; then
-  echo "Downloading precompiled binary from $ARCHIVE_URL…"
+  echo "Downloading precompiled binary from ${ARCHIVE_URL} …"
   curl -L -o cargo-machete.tar.gz "$ARCHIVE_URL"
   tar -xzf cargo-machete.tar.gz
   mv cargo*/cargo-machete /usr/local/bin/cargo-machete


### PR DESCRIPTION
The variable isn't separated cleanly when things are interpreted


```
 Determining Rust target triple...
Found TRIPLE=aarch64-apple-darwin.
Found VERSION=v0.9.1.
/Users/runner/work/_actions/bnjbvr/cargo-machete/main/action/entrypoint.sh: line 22: ARCHIVE_URL�: unbound variable
```
