### PR TITLE
perf: remove needless allocations

### DIFF
--- a/src/search_unused.rs
+++ b/src/search_unused.rs
@@ -514,7 +514,7 @@ impl Sink for StopAfterFirstMatch {
         _searcher: &searcher::Searcher,
         matsh: &searcher::SinkMatch<'_>,
     ) -> Result<bool, Self::Error> {
-        let mat = String::from_utf8(matsh.bytes().to_vec())?;
+        let mat = std::str::from_utf8(matsh.bytes())?;
         let mat = mat.trim();
 
         if mat.starts_with("//") || mat.starts_with("//!") {


### PR DESCRIPTION
# Description

I spotted this needless allocation while looking at the code to speed it up a bit further somehow.

# Benchmark

`hyperfine "cargo machete" "./target/release/cargo-machete" -i`

```
Benchmark 1: cargo machete
  Time (mean ± σ):      60.1 ms ±  13.6 ms    [User: 485.2 ms, System: 64.5 ms]
  Range (min … max):    38.9 ms …  90.2 ms    31 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: ./target/release/cargo-machete
  Time (mean ± σ):      45.4 ms ±   8.8 ms    [User: 524.8 ms, System: 63.5 ms]
  Range (min … max):    22.6 ms …  62.3 ms    51 runs

  Warning: Ignoring non-zero exit code.

Summary
  ./target/release/cargo-machete ran
    1.32 ± 0.39 times faster than cargo machete
```

To be fair: This difference grows smaller for bigger codebases: I cloned `bevyengine/bevy`, a big rust repo into the tree and ran the same test again.

```
Benchmark 1: cargo machete
  Time (mean ± σ):     532.0 ms ±  19.9 ms    [User: 8356.0 ms, System: 327.8 ms]
  Range (min … max):   504.4 ms … 558.8 ms    10 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: ./target/release/cargo-machete
  Time (mean ± σ):     474.9 ms ±   9.8 ms    [User: 7952.4 ms, System: 249.6 ms]
  Range (min … max):   464.0 ms … 496.5 ms    10 runs

  Warning: Ignoring non-zero exit code.

Summary
  ./target/release/cargo-machete ran
    1.12 ± 0.05 times faster than cargo machete
```