### PR TITLE
fix(musl): use jemalloc with x86_64-unknown-linux-musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "pretty_env_logger",
  "rayon",
  "serde",
+ "tikv-jemallocator",
  "toml_edit",
  "walkdir",
 ]
@@ -118,6 +119,16 @@ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
  "toml",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -193,6 +204,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "globset"
@@ -523,6 +540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +583,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ serde = "1.0.228"
 toml_edit = "0.25.5"
 walkdir = "2.5.0"
 
+# musl's default allocator is very slow when used from multiple threads (e.g. rayon)
+#
+# see https://github.com/BurntSushi/ripgrep/issues/1268#issuecomment-486432534
+[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies]
+tikv-jemallocator = { version = "0.6.1" }
+
 # Uncomment this for profiling.
 #[profile.release]
 #debug = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,14 @@ use std::str::FromStr;
 use std::{borrow::Cow, fs, path::PathBuf};
 use toml_edit::{KeyMut, TableLike};
 
+/// Use jemalloc on 64-bit musl since musl's default allocator is very slow when used from multiple
+/// threads (e.g. when using rayon).
+///
+/// See https://github.com/BurntSushi/ripgrep/issues/1268#issuecomment-486432534
+#[cfg(all(target_env = "musl", target_pointer_width = "64"))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[derive(Clone, Copy)]
 pub(crate) enum UseCargoMetadata {
     Yes,


### PR DESCRIPTION
This gives us a ~50x improvement when using `cargo-machete` at work.

Rough timings for our monorepo of 150kloc and just under 1k rust files (`cargo build --release --target={}` at `b81ce156`):

- `x86_64-unknown-linux-gnu`: ~0.9s
- `x86_64-unknown-linux-musl`: ~50s
- `x86_64-unknown-linux-musl`: ~1.5s (with this commit)

`jemalloc` is always used on 64-bit musl.